### PR TITLE
Fix: Missing dropTable for xcoin_v_account_balance

### DIFF
--- a/migrations/uninstall.php
+++ b/migrations/uninstall.php
@@ -12,6 +12,7 @@ class uninstall extends Migration
         $this->dropTable('xcoin_exchange');
         $this->dropTable('xcoin_funding');
         $this->dropTable('xcoin_transaction');
+        $this->dropTable('xcoin_v_account_balance');
     }
 
     public function down()


### PR DESCRIPTION
Of course, if you want to keep this table I'm fine with it.