### PR TITLE
Fix: className() change to class

### DIFF
--- a/Events.php
+++ b/Events.php
@@ -92,11 +92,11 @@ class Events
 
         if ($user->isModuleEnabled('xcoin')) {
 
-            $event->sender->addItem(array(
+            $event->sender->addItem([
                 'label' => '---',
                 'url' => '#',
                 'sortOrder' => 205,
-            ));
+            ]);
             $event->sender->addItem([
                 'label' => Yii::t('XcoinModule.base', 'Accounts'),
                 'url' => $user->createUrl('/xcoin/overview'),

--- a/config.php
+++ b/config.php
@@ -10,10 +10,10 @@ return [
     'class' => 'humhub\modules\xcoin\Module',
     'namespace' => 'humhub\modules\xcoin',
     'events' => [
-        ['class' => Menu::className(), 'event' => Menu::EVENT_INIT, 'callback' => ['humhub\modules\xcoin\Events', 'onSpaceMenuInit']],
-        ['class' => ProfileMenu::className(), 'event' => ProfileMenu::EVENT_INIT, 'callback' => ['humhub\modules\xcoin\Events', 'onProfileMenuInit']],
-        ['class' => TopMenu::className(), 'event' => TopMenu::EVENT_INIT, 'callback' => ['humhub\modules\xcoin\Events', 'onTopMenuInit']],
-        ['class' => AccountTopMenu::className(), 'event' => TopMenu::EVENT_INIT, 'callback' => ['humhub\modules\xcoin\Events', 'onAccountTopMenuInit']],
+        ['class' => Menu::class, 'event' => Menu::EVENT_INIT, 'callback' => ['humhub\modules\xcoin\Events', 'onSpaceMenuInit']],
+        ['class' => ProfileMenu::class, 'event' => ProfileMenu::EVENT_INIT, 'callback' => ['humhub\modules\xcoin\Events', 'onProfileMenuInit']],
+        ['class' => TopMenu::class, 'event' => TopMenu::EVENT_INIT, 'callback' => ['humhub\modules\xcoin\Events', 'onTopMenuInit']],
+        ['class' => AccountTopMenu::class, 'event' => TopMenu::EVENT_INIT, 'callback' => ['humhub\modules\xcoin\Events', 'onAccountTopMenuInit']],
     ],
 ];
 ?>

--- a/docs/CHANGELOGS.md
+++ b/docs/CHANGELOGS.md
@@ -1,0 +1,4 @@
+# Changelogs
+
+- Fix: className() change to class
+- Chg: Fixed missing short array in Events.php

--- a/models/Account.php
+++ b/models/Account.php
@@ -108,7 +108,7 @@ class Account extends \yii\db\ActiveRecord
      */
     public function getSpace()
     {
-        return $this->hasOne(Space::className(), ['id' => 'space_id']);
+        return $this->hasOne(Space::class, ['id' => 'space_id']);
     }
 
     /**
@@ -116,7 +116,7 @@ class Account extends \yii\db\ActiveRecord
      */
     public function getUser()
     {
-        return $this->hasOne(User::className(), ['id' => 'user_id']);
+        return $this->hasOne(User::class, ['id' => 'user_id']);
     }
 
     /**
@@ -124,7 +124,7 @@ class Account extends \yii\db\ActiveRecord
      */
     public function getTransactionsFrom()
     {
-        return $this->hasMany(Transaction::className(), ['from_account_id' => 'id']);
+        return $this->hasMany(Transaction::class, ['from_account_id' => 'id']);
     }
 
     /**
@@ -132,7 +132,7 @@ class Account extends \yii\db\ActiveRecord
      */
     public function getTransactionsTo()
     {
-        return $this->hasMany(Transaction::className(), ['to_account_id' => 'id']);
+        return $this->hasMany(Transaction::class, ['to_account_id' => 'id']);
     }
 
     /**
@@ -159,7 +159,7 @@ class Account extends \yii\db\ActiveRecord
      */
     public function getBalances()
     {
-        return $this->hasMany(AccountBalance::className(), ['account_id' => 'id']);
+        return $this->hasMany(AccountBalance::class, ['account_id' => 'id']);
     }
 
     /**

--- a/models/Asset.php
+++ b/models/Asset.php
@@ -68,7 +68,7 @@ class Asset extends \yii\db\ActiveRecord
      */
     public function getSpace()
     {
-        return $this->hasOne(Space::className(), ['id' => 'space_id']);
+        return $this->hasOne(Space::class, ['id' => 'space_id']);
     }
 
     /**
@@ -76,7 +76,7 @@ class Asset extends \yii\db\ActiveRecord
      */
     public function getTransactions()
     {
-        return $this->hasMany(Transaction::className(), ['asset_id' => 'id']);
+        return $this->hasMany(Transaction::class, ['asset_id' => 'id']);
     }
 
     public function getIssuedAmount()

--- a/models/Exchange.php
+++ b/models/Exchange.php
@@ -92,7 +92,7 @@ class Exchange extends \yii\db\ActiveRecord
      */
     public function getAccount()
     {
-        return $this->hasOne(Account::className(), ['id' => 'account_id']);
+        return $this->hasOne(Account::class, ['id' => 'account_id']);
     }
 
     /**
@@ -100,7 +100,7 @@ class Exchange extends \yii\db\ActiveRecord
      */
     public function getAsset()
     {
-        return $this->hasOne(Asset::className(), ['id' => 'asset_id']);
+        return $this->hasOne(Asset::class, ['id' => 'asset_id']);
     }
 
     /**
@@ -108,7 +108,7 @@ class Exchange extends \yii\db\ActiveRecord
      */
     public function getWantedAsset()
     {
-        return $this->hasOne(Asset::className(), ['id' => 'wanted_asset_id']);
+        return $this->hasOne(Asset::class, ['id' => 'wanted_asset_id']);
     }
 
     public function beforeSave($insert)

--- a/models/Funding.php
+++ b/models/Funding.php
@@ -95,7 +95,7 @@ class Funding extends \yii\db\ActiveRecord
      */
     public function getAsset()
     {
-        return $this->hasOne(Asset::className(), ['id' => 'asset_id']);
+        return $this->hasOne(Asset::class, ['id' => 'asset_id']);
     }
 
     /**
@@ -103,7 +103,7 @@ class Funding extends \yii\db\ActiveRecord
      */
     public function getCreatedBy()
     {
-        return $this->hasOne(User::className(), ['id' => 'created_by']);
+        return $this->hasOne(User::class, ['id' => 'created_by']);
     }
 
     /**
@@ -111,7 +111,7 @@ class Funding extends \yii\db\ActiveRecord
      */
     public function getSpace()
     {
-        return $this->hasOne(Space::className(), ['id' => 'space_id']);
+        return $this->hasOne(Space::class, ['id' => 'space_id']);
     }
 
     

--- a/models/Transaction.php
+++ b/models/Transaction.php
@@ -118,7 +118,7 @@ class Transaction extends \yii\db\ActiveRecord
      */
     public function getAsset()
     {
-        return $this->hasOne(Asset::className(), ['id' => 'asset_id']);
+        return $this->hasOne(Asset::class, ['id' => 'asset_id']);
     }
 
     /**
@@ -126,7 +126,7 @@ class Transaction extends \yii\db\ActiveRecord
      */
     public function getFromAccount()
     {
-        return $this->hasOne(Account::className(), ['id' => 'from_account_id']);
+        return $this->hasOne(Account::class, ['id' => 'from_account_id']);
     }
 
     /**
@@ -134,7 +134,7 @@ class Transaction extends \yii\db\ActiveRecord
      */
     public function getToAccount()
     {
-        return $this->hasOne(Account::className(), ['id' => 'to_account_id']);
+        return $this->hasOne(Account::class, ['id' => 'to_account_id']);
     }
 
 }

--- a/views/account/edit.php
+++ b/views/account/edit.php
@@ -15,7 +15,7 @@ use humhub\modules\user\widgets\UserPickerField;
     <?= $form->field($account, 'title'); ?>
     <?php if ($account->isNewRecord && empty($account->user_id)) : ?>
         <?=
-        $form->field($account, 'editFieldManager')->widget(UserPickerField::className(), [
+        $form->field($account, 'editFieldManager')->widget(UserPickerField::class, [
             'maxSelection' => 1,
         ]);
         ?>

--- a/views/exchange/offer.php
+++ b/views/exchange/offer.php
@@ -50,7 +50,7 @@ Select2BootstrapAsset::register($this);
     <div class="row blockDefineExchangeRate">
         <div class="col-md-6">
             <?=
-            $form->field($exchange, 'wanted_asset_id')->widget(Select2::classname(), [
+            $form->field($exchange, 'wanted_asset_id')->widget(Select2::class, [
                 'data' => $assetList,
                 'options' => ['placeholder' => '- Select asset - '],
                 'theme' => Select2::THEME_BOOTSTRAP,

--- a/views/funding/create.php
+++ b/views/funding/create.php
@@ -18,7 +18,7 @@ Select2BootstrapAsset::register($this);
 <?= Html::hiddenInput('step', '1'); ?>
 <div class="modal-body">
     <?=
-    $form->field($model, 'asset_id')->widget(Select2::classname(), [
+    $form->field($model, 'asset_id')->widget(Select2::class, [
         'data' => $assetList,
         'options' => ['placeholder' => '- Select asset - '],
         'theme' => Select2::THEME_BOOTSTRAP,

--- a/views/funding/edit.php
+++ b/views/funding/edit.php
@@ -20,7 +20,7 @@ Select2BootstrapAsset::register($this);
 
 <div class="modal-body">
     <?= $form->field($model, 'asset_id')->hiddenInput()->label(false) ?>
-    <?= $form->field($model, 'available_amount')->widget(AmountField::classname(), ['asset' => $myAsset])->label(Yii::t('XcoinModule.base', 'Maximum offered amount')); ?>
+    <?= $form->field($model, 'available_amount')->widget(AmountField::class, ['asset' => $myAsset])->label(Yii::t('XcoinModule.base', 'Maximum offered amount')); ?>
     <p class='alert alert-info'>
         The current balance of the funding account is: <strong><?= $fundingAccountBalance; ?></strong>
     </p>
@@ -28,13 +28,13 @@ Select2BootstrapAsset::register($this);
     <p><?= Yii::t('XcoinModule.base', 'Determine the exchange rate for which you are willing to trade assets.'); ?></p>
     <div class="row">
         <div class = "col-md-5">
-            <?= $form->field($model, 'exchange_rate')->widget(AmountField::classname(), ['asset' => $myAsset])->label(Yii::t('XcoinModule.base', 'Provided asset')); ?>
+            <?= $form->field($model, 'exchange_rate')->widget(AmountField::class, ['asset' => $myAsset])->label(Yii::t('XcoinModule.base', 'Provided asset')); ?>
         </div>
         <div class="col-md-2 text-center">
             <i class="fa fa-exchange colorSuccess" style="font-size:28px;padding-top:24px" aria-hidden="true"></i>
         </div>
         <div class="col-md-5">
-            <?= $form->field($model, 'amount')->widget(AmountField::classname(), ['asset' => $model->asset, 'readonly' => true])->label(Yii::t('XcoinModule.base', 'Requested asset')); ?>
+            <?= $form->field($model, 'amount')->widget(AmountField::class, ['asset' => $model->asset, 'readonly' => true])->label(Yii::t('XcoinModule.base', 'Requested asset')); ?>
         </div>
     </div>
 

--- a/views/funding/invest.php
+++ b/views/funding/invest.php
@@ -18,10 +18,10 @@ Select2BootstrapAsset::register($this);
 
     <div class="row">
         <div class="col-md-6">
-            <?= $form->field($model, 'amountPay')->widget(AmountField::classname(), ['asset' => $model->getPayAsset()]); ?>
+            <?= $form->field($model, 'amountPay')->widget(AmountField::class, ['asset' => $model->getPayAsset()]); ?>
         </div>
         <div class = "col-md-6">
-            <?= $form->field($model, 'amountBuy')->widget(AmountField::classname(), ['asset' => $model->getBuyAsset(), 'readonly' => true]); ?>
+            <?= $form->field($model, 'amountBuy')->widget(AmountField::class, ['asset' => $model->getBuyAsset(), 'readonly' => true]); ?>
         </div>
     </div>
 </div>

--- a/widgets/AccountField.php
+++ b/widgets/AccountField.php
@@ -1,10 +1,4 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: Luke
- * Date: 28.02.2018
- * Time: 09:13
- */
 
 namespace humhub\modules\xcoin\widgets;
 
@@ -169,7 +163,7 @@ class AccountField extends InputWidget
 
     protected function getFieldId($fieldName)
     {
-        return crc32($this->model->className() . $this->attribute . $fieldName);
+        return crc32($this->model->class . $this->attribute . $fieldName);
     }
 
 }

--- a/widgets/AccountField.php
+++ b/widgets/AccountField.php
@@ -163,7 +163,7 @@ class AccountField extends InputWidget
 
     protected function getFieldId($fieldName)
     {
-        return crc32($this->model->class . $this->attribute . $fieldName);
+        return crc32($this->model->className() . $this->attribute . $fieldName);
     }
 
 }


### PR DESCRIPTION
This deals with a lot of fixes to the `className()` issues, also changes one array in Events.php to short array but that's a minor issue.

> Note: In `/widgets/AccountField.php` on [line 172](https://github.com/Coinsence/humhub-modules-xcoin/blob/master/widgets/AccountField.php#L172) I'm not exactly sure if this should or shouldn't be replaced with class or not, any advice would be appreciated! :smile: