### PR TITLE
altering queue table 

### DIFF
--- a/migrations/m190709_130645_increase_queue_job_db_column_size.php
+++ b/migrations/m190709_130645_increase_queue_job_db_column_size.php
@@ -1,0 +1,25 @@
+<?php
+
+use yii\db\Migration;
+
+/**
+ * Class m190709_130645_increase_queue_job_db_column_size
+ */
+class m190709_130645_increase_queue_job_db_column_size extends Migration
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function safeUp()
+    {
+        $this->alterColumn('queue', 'job', 'LONGBLOB');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function safeDown()
+    {
+        $this->alterColumn('queue', 'job', $this->binary()->notNull());
+    }
+}


### PR DESCRIPTION
changing `job` column in `queue` table from `blob` -> `longblob` in order to increase size needed for heavy space ethereum migration