### PR TITLE
restore the crowdfunding richtext block

### DIFF
--- a/views/funding/overview.php
+++ b/views/funding/overview.php
@@ -172,6 +172,10 @@ Assets::register($this);
                                     <!-- campaign raised end -->
                                 </div>
 
+                                <!-- campaign content start -->
+                                <?= RichText::output($funding->content); ?>
+                                <!-- campaign content end -->
+
 
                             </div>
                             <div class="panel-footer">


### PR DESCRIPTION
fix no long description in the crowdfunding overview